### PR TITLE
Youtube privacy

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -23,20 +23,20 @@ return [
     new AddFofComponents(),
 
     (new Extend\Frontend('forum'))
-        ->css(__DIR__ . '/resources/less/forum.less'),
+        ->css(__DIR__.'/resources/less/forum.less'),
 
     (new Extend\Frontend('admin'))
-        ->js(__DIR__ . '/js/dist/admin.js')
-        ->css(__DIR__ . '/resources/less/admin.less'),
+        ->js(__DIR__.'/js/dist/admin.js')
+        ->css(__DIR__.'/resources/less/admin.less'),
 
-    new Extend\Locales(__DIR__ . '/resources/locale'),
+    new Extend\Locales(__DIR__.'/resources/locale'),
 
     (new Extend\Formatter())
         ->configure(function (Configurator $configurator) {
             $settings = resolve('flarum.settings');
 
             foreach (FormatterConfigurator::PLUGINS as $plugin) {
-                $enabled = $settings->get('fof-formatting.plugin.' . strtolower($plugin));
+                $enabled = $settings->get('fof-formatting.plugin.'.strtolower($plugin));
 
                 if ($enabled) {
                     if ($plugin == 'MediaEmbed') {

--- a/extend.php
+++ b/extend.php
@@ -23,24 +23,29 @@ return [
     new AddFofComponents(),
 
     (new Extend\Frontend('forum'))
-        ->css(__DIR__.'/resources/less/forum.less'),
+        ->css(__DIR__ . '/resources/less/forum.less'),
 
     (new Extend\Frontend('admin'))
-        ->js(__DIR__.'/js/dist/admin.js')
-        ->css(__DIR__.'/resources/less/admin.less'),
+        ->js(__DIR__ . '/js/dist/admin.js')
+        ->css(__DIR__ . '/resources/less/admin.less'),
 
-    new Extend\Locales(__DIR__.'/resources/locale'),
+    new Extend\Locales(__DIR__ . '/resources/locale'),
 
     (new Extend\Formatter())
         ->configure(function (Configurator $configurator) {
             $settings = resolve('flarum.settings');
 
             foreach (FormatterConfigurator::PLUGINS as $plugin) {
-                $enabled = $settings->get('fof-formatting.plugin.'.strtolower($plugin));
+                $enabled = $settings->get('fof-formatting.plugin.' . strtolower($plugin));
 
                 if ($enabled) {
                     if ($plugin == 'MediaEmbed') {
                         (new MediaPack())->configure($configurator);
+
+                        $configurator->MediaEmbed->add('youtube');
+
+                        $tag = $configurator->tags['YOUTUBE'];
+                        $tag->template = str_replace('www.youtube.com', 'www.youtube-nocookie.com', $tag->template);
                     } else {
                         $configurator->$plugin;
                     }


### PR DESCRIPTION
Modifies the Youtube embed template to render `youtube-nocookie.com` in place of `youtube.com`, for privacy focussed reasons.

However, we need to consider:

- Forcing this may or may not be popular
- To date, this extension has been config free, so placing this behind an option would go against that
- Maybe this should be left to forum admins to set in their local `extend.php`
- Or this should be a seperate micro-extension.

Anyhow, I'll leave this here for a while to gather comments, opinions, etc